### PR TITLE
add Dockerfile to package adapt as a Docker image

### DIFF
--- a/docker_hub/Dockerfile
+++ b/docker_hub/Dockerfile
@@ -2,7 +2,7 @@ FROM alpine:3.10.3
 ARG ADAPT_VERSION
 
 # Install Adapt and its prerequisites.
-RUN apk --update add --no-cache nodejs npm openssh-client
+RUN apk --update add --no-cache 'nodejs=~10.16' 'npm=~10.16' 'openssh-client=~8.1'
 RUN npm install -g yarn@~1.19 @adpt/cli@$ADAPT_VERSION
 
 # Setup volumes where users should mount the source root of their project and

--- a/docker_hub/Dockerfile
+++ b/docker_hub/Dockerfile
@@ -1,0 +1,9 @@
+FROM alpine:latest
+ARG ADAPT_VERSION
+RUN apk --update add --no-cache nodejs npm openssh \
+  && rm -rf /var/cache/apk/*
+RUN npm install -g @adpt/cli@$ADAPT_VERSION
+RUN mkdir /src
+VOLUME ["/src"]
+WORKDIR /src
+ENTRYPOINT ["/usr/bin/adapt"]

--- a/docker_hub/Dockerfile
+++ b/docker_hub/Dockerfile
@@ -1,9 +1,15 @@
-FROM alpine:latest
+FROM alpine:3.10.3
 ARG ADAPT_VERSION
-RUN apk --update add --no-cache nodejs npm openssh \
-  && rm -rf /var/cache/apk/*
-RUN npm install -g @adpt/cli@$ADAPT_VERSION
-RUN mkdir /src
-VOLUME ["/src"]
+
+# Install Adapt and its prerequisites.
+RUN apk --update add --no-cache nodejs npm openssh-client
+RUN npm install -g yarn@~1.19 @adpt/cli@$ADAPT_VERSION
+
+# Setup volumes where users should mount the source root of their project and
+# their configuration directory.
+RUN mkdir -p /src /root/.local/share/adapt /root/.ssh
+VOLUME ["/src", "/root/.local/share/adapt", "/root/.ssh"]
+
+# Default to running Adapt from the mounted source root volume.
 WORKDIR /src
 ENTRYPOINT ["/usr/bin/adapt"]

--- a/docker_hub/README.md
+++ b/docker_hub/README.md
@@ -1,10 +1,22 @@
+# Adapt Docker Image
+
+## Building the image
+
+Build the Adapt Docker image as follows (replacing `VERSION` with the version of Adapt that
+you want packaged):
+
+```
+cd docker_hub
+./build.sh VERSION
+```
+
+## Using the image
+
 Use the Adapt Docker image as follows:
 
-1. Pull the adapt image to your machine: `docker pull adapt:latest`
+1. Pull the adapt image to your machine: `docker pull unboundedsystems/adapt:latest`
 
-2. If you are using git, add this alias to your `.bashrc`:
-
-```
-alias adapt='docker run --rm -ti -v $(pwd):/src  -v ~/.local/share/adapt:/root/.local/share/adapt -v ~/.ssh:/root/.ssh adapt:latest'
-```
+2. Store the `bash-alias.sh` file somewhere and edit your ~/.bashrc startup file to contain (and then restart
+your shell): ```source /path/to/bash-alias.sh```
  
+3. You should now have an `adapt` shell function that will run Adapt for you using Docker.

--- a/docker_hub/README.md
+++ b/docker_hub/README.md
@@ -1,0 +1,10 @@
+Use the Adapt Docker image as follows:
+
+1. Pull the adapt image to your machine: `docker pull adapt:latest`
+
+2. If you are using git, add this alias to your `.bashrc`:
+
+```
+alias adapt='docker run --rm -ti -v $(pwd):/src  -v ~/.local/share/adapt:/root/.local/share/adapt -v ~/.ssh:/root/.ssh adapt:latest'
+```
+ 

--- a/docker_hub/bash-alias.sh
+++ b/docker_hub/bash-alias.sh
@@ -1,0 +1,18 @@
+# Use the Bash `source` command to read this file in your ~/.bashrc.
+
+adapt() {
+  local image_name='unboundedsystems/adapt:latest'  
+
+  if ! docker image inspect "$image_name" >/dev/null 2>&1 ; then
+    docker pull "$image_name"
+  fi
+
+  mkdir -p ~/.local/share/adapt
+
+  docker run --rm -ti \
+    -v "$(pwd):/src/" \
+    -v "${HOME}/.local/share/adapt:/root/.local/share/adapt" \
+    -v "${HOME}/.ssh:/root/.ssh" \
+    "$image_name" \
+    "$@"
+}

--- a/docker_hub/build.sh
+++ b/docker_hub/build.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+version="$1"
+shift
+
+if [ -z "$version" ]; then
+  echo "usage: $0 VERSION" 1>&2
+  exit 1
+fi
+
+toplevel=$(git rev-parse --show-toplevel)
+
+docker build \
+  -f "${toplevel}/docker_hub/Dockerfile" \
+  --build-arg ADAPT_VERSION="$version" \
+  -t "adapt:${version}" \
+  -t "adapt:latest" \
+  "${toplevel}/docker_hub"

--- a/docker_hub/build.sh
+++ b/docker_hub/build.sh
@@ -13,6 +13,6 @@ toplevel=$(git rev-parse --show-toplevel)
 docker build \
   -f "${toplevel}/docker_hub/Dockerfile" \
   --build-arg ADAPT_VERSION="$version" \
-  -t "adapt:${version}" \
-  -t "adapt:latest" \
+  -t "unboundedsystems/adapt:${version}" \
+  -t "unboundedsystems/adapt:latest" \
   "${toplevel}/docker_hub"


### PR DESCRIPTION
Add a `Dockerfile` and build script to package adapt into a Docker image for easy consumption. This fails to build currently though due to `npm` trying a SSH GitHub link for the `listr` dependency instead of https.

Maybe the reference to listr in `cli/package.json` should be `git+https://github.com/unboundedsystems/list.gitr#v0.14.3-unb3`?

Output:
```
~/Projects/Adapt/adapt$ docker_hub/build.sh 0.0.6
Sending build context to Docker daemon  3.072kB
Step 1/5 : FROM alpine:latest
 ---> 965ea09ff2eb
Step 2/5 : ARG ADAPT_VERSION
 ---> Running in f9b4c9428c2b
Removing intermediate container f9b4c9428c2b
 ---> e2809e861ee5
Step 3/5 : RUN apk --update add --no-cache nodejs npm   && rm -rf /var/cache/apk/*
 ---> Running in 59abd802587d
fetch http://dl-cdn.alpinelinux.org/alpine/v3.10/main/x86_64/APKINDEX.tar.gz
fetch http://dl-cdn.alpinelinux.org/alpine/v3.10/community/x86_64/APKINDEX.tar.gz
(1/8) Installing ca-certificates (20190108-r0)
(2/8) Installing c-ares (1.15.0-r0)
(3/8) Installing libgcc (8.3.0-r0)
(4/8) Installing http-parser (2.9.2-r0)
(5/8) Installing libstdc++ (8.3.0-r0)
(6/8) Installing libuv (1.29.1-r0)
(7/8) Installing nodejs (10.16.3-r0)
(8/8) Installing npm (10.16.3-r0)
Executing busybox-1.30.1-r2.trigger
Executing ca-certificates-20190108-r0.trigger
OK: 59 MiB in 22 packages
Removing intermediate container 59abd802587d
 ---> a39bb292fac3
Step 4/5 : RUN npm install -g @adpt/cli@$ADAPT_VERSION
 ---> Running in 06ceae539bda
npm ERR! path git
npm ERR! code ENOENT
npm ERR! errno ENOENT
npm ERR! syscall spawn git
npm ERR! enoent Error while executing:
npm ERR! enoent undefined ls-remote -h -t ssh://git@github.com/unboundedsystems/listr.git
npm ERR! enoent 
npm ERR! enoent 
npm ERR! enoent spawn git ENOENT
npm ERR! enoent This is related to npm not being able to find a file.
npm ERR! enoent 

npm ERR! A complete log of this run can be found in:
npm ERR!     /root/.npm/_logs/2019-11-21T20_33_38_940Z-debug.log
The command '/bin/sh -c npm install -g @adpt/cli@$ADAPT_VERSION' returned a non-zero code: 1
```
