### PR TITLE
initial bindings of AWS Lambda resources

### DIFF
--- a/cloud/src/aws/lambda/Alias.tsx
+++ b/cloud/src/aws/lambda/Alias.tsx
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2020 Unbounded Systems, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Adapt, { Component } from "@adpt/core";
+import {removeUndef} from "@adpt/utils";
+import {CFResource} from "../CFResource";
+import {withCredentials, WithCredentials} from "../credentials";
+
+// Lambda - Alias
+// CF Docs: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-alias.html
+
+export interface AliasProps extends WithCredentials {
+    description?: string;
+    functionName: string;
+    functionVersion: string;
+    name: string;
+    provisionedConcurrencyConfig?: ProvisionedConcurrencyConfiguration;
+    routingConfig?: AliasRoutingConfiguration;
+}
+
+export interface ProvisionedConcurrencyConfiguration {
+    ProvisionedConcurrentExecutions: number;
+}
+
+export interface AliasRoutingConfiguration {
+    AdditionalVersionWeights: FunctionWeight[];
+}
+
+export interface FunctionWeight {
+    FunctionVersion: string;
+    FunctionWeight: number;
+}
+
+class AliasNC extends Component<AliasProps> {
+    build() {
+        const props = this.props;
+
+        const properties = removeUndef({
+            Description: props.description,
+            FunctionName: props.functionName,
+            FunctionVersion: props.functionVersion,
+            Name: props.name,
+            ProvisionedConcurrencyConfig: props.provisionedConcurrencyConfig,
+            RoutingConfig: props.routingConfig,
+        });
+
+        return (
+            <CFResource
+                Type="AWS::Lambda::Alias"
+                Properties={properties}
+            />
+        );
+    }
+}
+
+// tslint:disable-next-line:variable-name
+export const Alias = withCredentials(AliasNC);
+export default Alias;

--- a/cloud/src/aws/lambda/EventInvokeConfig.tsx
+++ b/cloud/src/aws/lambda/EventInvokeConfig.tsx
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2020 Unbounded Systems, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Adapt, { Component } from "@adpt/core";
+import {removeUndef} from "@adpt/utils";
+import {CFResource} from "../CFResource";
+import {withCredentials, WithCredentials} from "../credentials";
+
+// Lambda - Event Invoke Config
+// CF Docs: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-eventinvokeconfig.html
+
+export interface EventInvokeConfigProps extends WithCredentials {
+    destinationConfig?: DestinationConfig;
+    functionName: string;
+    maximumEventAgeInSeconds?: number;
+    maximumRetryAttempts?: number;
+    qualifier: string;
+}
+
+export interface DestinationConfig {
+    OnFailure?: OnFailure;
+    OnSuccess?: OnSuccess;
+}
+
+export interface OnFailure {
+    Destination: string;
+}
+
+export interface OnSuccess {
+    Destination: string;
+}
+
+class EventInvokeConfigNC extends Component<EventInvokeConfigProps> {
+    build() {
+        const props = this.props;
+
+        const properties = removeUndef({
+            DestinationConfig: props.destinationConfig,
+            FunctionName: props.functionName,
+            MaximumEventAgeInSeconds: props.maximumEventAgeInSeconds,
+            MaximumRetryAttempts: props.maximumRetryAttempts,
+            Qualifier: props.qualifier
+        });
+
+        return (
+            <CFResource
+                Type="AWS::Lambda::EventInvokeConfig"
+                Properties={properties}
+            />
+        );
+    }
+}
+
+// tslint:disable-next-line:variable-name
+export const EventInvokeConfig = withCredentials(EventInvokeConfigNC);
+export default EventInvokeConfig;

--- a/cloud/src/aws/lambda/EventSourceMapping.tsx
+++ b/cloud/src/aws/lambda/EventSourceMapping.tsx
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2020 Unbounded Systems, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Adapt, { Component } from "@adpt/core";
+import {removeUndef} from "@adpt/utils";
+import {CFResource} from "../CFResource";
+import {withCredentials, WithCredentials} from "../credentials";
+
+// Lambda - Event Source Mapping
+// CF Docs: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-eventsourcemapping.html
+
+export interface EventSourceMappingProps extends WithCredentials {
+    batchSize?: number;
+    bisectBatchOnFunctionError?: boolean;
+    destinationConfig?: DestinationConfig;
+    enabled?: boolean;
+    eventSourceArn: string;
+    functionName: string;
+    maximumBatchingWindowInSeconds?: number;
+    maximumRecordAgeInSeconds?: number;
+    maximumRetryAttempts?: number;
+    parallelizationFactor?: number;
+    startingPosition?: string;
+}
+
+export interface DestinationConfig {
+    OnFailure: OnFailure;
+}
+
+export interface OnFailure {
+    Destination: string;
+}
+
+class EventSourceMappingNC extends Component<EventSourceMappingProps> {
+    build() {
+        const props = this.props;
+
+        const properties = removeUndef({
+            BatchSize: props.batchSize,
+            BisectBatchOnFunctionError: props.bisectBatchOnFunctionError,
+            DestinationConfig: props.destinationConfig,
+            Enabled: props.enabled,
+            EventSourceArn: props.eventSourceArn,
+            FunctionName: props.functionName,
+            MaximumBatchingWindowInSeconds: props.maximumBatchingWindowInSeconds,
+            MaximumRecordAgeInSeconds: props.maximumRecordAgeInSeconds,
+            MaximumRetryAttempts: props.maximumRetryAttempts,
+            ParallelizationFactor: props.parallelizationFactor,
+            StartingPosition: props.startingPosition,
+        });
+
+        return (
+            <CFResource
+                Type="AWS::Lambda::EventSourceMapping"
+                Properties={properties}
+            />
+        );
+    }
+}
+
+// tslint:disable-next-line:variable-name
+export const EventSourceMapping = withCredentials(EventSourceMappingNC);
+export default EventSourceMapping;

--- a/cloud/src/aws/lambda/Function.tsx
+++ b/cloud/src/aws/lambda/Function.tsx
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2020 Unbounded Systems, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Adapt, { Component } from "@adpt/core";
+import {removeUndef} from "@adpt/utils";
+import {CFResource} from "../CFResource";
+import {withCredentials, WithCredentials} from "../credentials";
+
+// Lambda - Function
+// CF Docs: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-lambda-function-code.html
+
+export interface FunctionProps extends WithCredentials {
+    code: Code;
+    deadLetterConfig?: DeadLetterConfig;
+    description?: string;
+    environment?: Environment;
+    functionName?: string;
+    handler: string;
+    kmsKeyArn?: string;
+    layers?: string[];
+    memorySize?: number;
+    reservedConcurrentExecutions?: number;
+    role: string;
+    runtime: string;
+    tags: {[key: string]: string};
+    timeout?: number;
+    tracingConfig?: TracingConfig;
+    vpcConfig?: VpcConfig;
+}
+
+export interface Code {
+    s3Bucket?: string;
+    s3Key?: string;
+    s3ObjectVersion?: string;
+    zipFile?: string;
+}
+
+export interface DeadLetterConfig {
+    targetARN?: string;
+}
+
+export interface Environment {
+    variables: {[key: string]: string};
+}
+
+export interface TracingConfig {
+    mode?: string;
+}
+
+export interface VpcConfig {
+    securityGroupIds: string[];
+    subnetIds: string[];
+}
+
+interface TagPair {
+    Key: string;
+    Value: string;
+}
+
+function convertTags(tags: {[key: string]: string}): TagPair[] {
+    const result = [];
+    for (const key in tags) {
+        if (tags.hasOwnProperty(key)) {
+            result.push({
+                Key: key,
+                Value: tags[key],
+            });
+        }
+    }
+    return result;
+}
+
+class FunctionNC extends Component<FunctionProps> {
+    build() {
+        const props = this.props;
+
+        const properties = removeUndef({
+            Code: props.code,
+            DeadLetterConfig: props.deadLetterConfig,
+            Description: props.description,
+            Environment: props.environment ? props.environment.variables : undefined,
+            FunctionName: props.functionName,
+            Handler: props.handler,
+            KmsKeyArn: props.kmsKeyArn,
+            Layers: props.layers,
+            MemorySize: props.memorySize,
+            ReservedConcurrentExecutions: props.reservedConcurrentExecutions,
+            Role: props.role,
+            Runtime: props.runtime,
+            Tags: convertTags(props.tags || {}),
+            Timeout: props.timeout,
+            TracingConfig: props.tracingConfig,
+            VpcConfig: props.vpcConfig,
+        });
+
+        return (
+            <CFResource
+                Type="AWS::Lambda::Function"
+                Properties={properties}
+            />
+        );
+    }
+}
+
+// tslint:disable-next-line:variable-name
+export const Function = withCredentials(FunctionNC);
+export default Function;

--- a/cloud/src/aws/lambda/LayerVersion.tsx
+++ b/cloud/src/aws/lambda/LayerVersion.tsx
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2020 Unbounded Systems, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Adapt, { Component } from "@adpt/core";
+import {removeUndef} from "@adpt/utils";
+import {CFResource} from "../CFResource";
+import {withCredentials, WithCredentials} from "../credentials";
+
+// Lambda - Layer Version
+// CF Docs: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-layerversion.html
+
+export interface LayerVersionProps extends WithCredentials {
+    compatibleRuntimes?: string[];
+    content: Content;
+    description?: string;
+    layerName: string;
+    licenseInfo: string;
+}
+
+export interface Content {
+    S3Bucket: string;
+    S3Key: string;
+    S3ObjectVersion?: string;
+}
+
+class LayerVersionNC extends Component<LayerVersionProps> {
+    build() {
+        const props = this.props;
+
+        const properties = removeUndef({
+            CompatibleRuntimes: props.compatibleRuntimes,
+            Content: props.content,
+            Description: props.description,
+            LayerName: props.layerName,
+            LicenseInfo: props.licenseInfo,
+        });
+
+        return (
+            <CFResource
+                Type="AWS::Lambda::LayerVersion"
+                Properties={properties}
+            />
+        );
+    }
+}
+
+// tslint:disable-next-line:variable-name
+export const LayerVersion = withCredentials(LayerVersionNC);
+export default LayerVersion;

--- a/cloud/src/aws/lambda/LayerVersionPermission.tsx
+++ b/cloud/src/aws/lambda/LayerVersionPermission.tsx
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2020 Unbounded Systems, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Adapt, { Component } from "@adpt/core";
+import {removeUndef} from "@adpt/utils";
+import {CFResource} from "../CFResource";
+import {withCredentials, WithCredentials} from "../credentials";
+
+// Lambda - Layer Version Permission
+// CF Docs:
+// https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-layerversionpermission.html
+
+export interface LayerVersionPermissionProps extends WithCredentials {
+    action: string;
+    layerVersionArn: string;
+    organizationId?: string;
+    principal: string;
+}
+
+class LayerVersionPermissionNC extends Component<LayerVersionPermissionProps> {
+    build() {
+        const props = this.props;
+
+        const properties = removeUndef({
+            Action: props.action,
+            LayerVersionArn: props.layerVersionArn,
+            OrganizationId: props.organizationId,
+            Principal: props.principal,
+        });
+
+        return (
+            <CFResource
+                Type="AWS::Lambda::LayerVersionPermission"
+                Properties={properties}
+            />
+        );
+    }
+}
+
+// tslint:disable-next-line:variable-name
+export const LayerVersionPermission = withCredentials(LayerVersionPermissionNC);
+export default LayerVersionPermission;

--- a/cloud/src/aws/lambda/Permission.tsx
+++ b/cloud/src/aws/lambda/Permission.tsx
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2020 Unbounded Systems, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Adapt, { Component } from "@adpt/core";
+import {removeUndef} from "@adpt/utils";
+import {CFResource} from "../CFResource";
+import {withCredentials, WithCredentials} from "../credentials";
+
+// Lambda - Permission
+// CF Docs: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-permission.html
+
+export interface PermissionProps extends WithCredentials {
+    action: string;
+    eventSourceToken?: string;
+    functionName: string;
+    principal: string;
+    sourceAccount?: string;
+    sourceArn: string;
+}
+
+class PermissionNC extends Component<PermissionProps> {
+    build() {
+        const props = this.props;
+
+        const properties = removeUndef({
+            Action: props.action,
+            EventSourceToken: props.eventSourceToken,
+            FunctionName: props.functionName,
+            Principal: props.principal,
+            SourceAccount: props.sourceAccount,
+            SourceArn: props.sourceArn,
+        });
+
+        return (
+            <CFResource
+                Type="AWS::Lambda::Permission"
+                Properties={properties}
+            />
+        );
+    }
+}
+
+// tslint:disable-next-line:variable-name
+export const Permission = withCredentials(PermissionNC);
+export default Permission;

--- a/cloud/src/aws/lambda/Version.tsx
+++ b/cloud/src/aws/lambda/Version.tsx
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2020 Unbounded Systems, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Adapt, { Component } from "@adpt/core";
+import {removeUndef} from "@adpt/utils";
+import {CFResource} from "../CFResource";
+import {withCredentials, WithCredentials} from "../credentials";
+
+// Lambda - Version
+// CF Docs: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-version.html
+
+export interface VersionProps extends WithCredentials {
+    codeSha256?: string;
+    description?: string;
+    functionName: string;
+    provisionedConcurrencyConfig?: ProvisionedConcurrencyConfiguration;
+}
+
+export interface ProvisionedConcurrencyConfiguration {
+    ProvisionedConcurrentExecutions: number;
+}
+
+class VersionNC extends Component<VersionProps> {
+    build() {
+        const props = this.props;
+
+        const properties = removeUndef({
+            CodeSha256: props.codeSha256,
+            Description: props.description,
+            FunctionName: props.functionName,
+            ProvisionedConcurrencyConfig: props.provisionedConcurrencyConfig,
+        });
+
+        return (
+            <CFResource
+                Type="AWS::Lambda::Version"
+                Properties={properties}
+            />
+        );
+    }
+}
+
+// tslint:disable-next-line:variable-name
+export const Version = withCredentials(VersionNC);
+export default Version;


### PR DESCRIPTION
@mvachhar / @mterrel:  Just putting this up for initial review before I write bindings for other parts of the AWS API. I wanted to get your feedback on style mainly. 

1. I've lowercased the first letter of the properties as I've seen in other parts of the code, but this requires turning them back to uppercase when forming the properties to use for `CFResource`. The sub-stucts do not do that (to make it easier for form the properties). Maybe all of the properties shoud be upper-cased?

2. Any comments otherwise? 